### PR TITLE
fix: QR not rendering - pin qrcode lib to 1.5.1

### DIFF
--- a/static/lr-mitra-qr.html
+++ b/static/lr-mitra-qr.html
@@ -78,8 +78,9 @@
     </footer>
   </main>
 
-  <!-- Pinned QR library, ~17 KB minified -->
-  <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js"></script>
+  <!-- Pinned QR library, ~17 KB minified. Stay on 1.5.1 - 1.5.3+ dropped the
+       build/ directory from the npm tarball so jsdelivr/unpkg return 404 for it. -->
+  <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.1/build/qrcode.min.js"></script>
   <script>
     // Stable filename - the latest release is always served at this URL, so
     // the encoded QR never goes stale. The release script copies the new APK


### PR DESCRIPTION
cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js now returns 404 because qrcode 1.5.3+ ships without the build/ directory in the npm tarball. With the library failing to load, window.QRCode was undefined and the if(window.QRCode) branch silently skipped, leaving the canvas empty.

1.5.1 still has the build/qrcode.min.js path intact and exposes the same QRCode.toCanvas API, so no code changes needed beyond the pin. Comment updated so the next person trying to upgrade knows why.