### PR TITLE
perf(llm): move JS-rendered content into static HTML

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,25 @@
+// Project override of themes/hugoplate/assets/js/main.js.
+// Upstream uses loop:true which Swiper implements by cloning slides into the
+// DOM at init — that duplicates testimonial text post-render and lowers the
+// LLM static-content score. With loop:false the static HTML matches the DOM.
+(function () {
+  "use strict";
+
+  new Swiper(".testimonial-slider", {
+    spaceBetween: 24,
+    loop: false,
+    pagination: {
+      el: ".testimonial-slider-pagination",
+      type: "bullets",
+      clickable: true,
+    },
+    breakpoints: {
+      768: {
+        slidesPerView: 2,
+      },
+      992: {
+        slidesPerView: 3,
+      },
+    },
+  });
+})();

--- a/content/english/products.md
+++ b/content/english/products.md
@@ -43,30 +43,31 @@ All paid plans include unlimited lorry receipts — no caps, no extra charges pe
 <div class="my-6 p-6 rounded-2xl bg-teal-50 dark:bg-teal-900/20 border border-teal-100 dark:border-teal-800">
   <p class="font-semibold text-lg mb-1">Custom Plan — for large fleets and enterprises</p>
   <p class="text-sm opacity-80 mb-3">Everything in Business, plus custom user & branch limits, custom integrations and reporting, and a dedicated account manager.</p>
-  <button type="button"
-    onclick="var f=document.getElementById('lr-mitra-custom-form');f.classList.remove('hidden');this.style.display='none';"
-    class="inline-flex items-center gap-2 bg-teal-700 text-white text-sm font-medium px-5 py-2.5 rounded-xl hover:bg-teal-800 transition-colors">
-    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
-    Contact us for pricing
-  </button>
-  <form id="lr-mitra-custom-form" class="hidden mt-4 space-y-3"
-        action="https://formspree.io/f/xeejoadk" method="POST">
-    <input type="hidden" name="_subject" value="LR Mitra Custom Plan Enquiry" />
-    <input type="hidden" name="product" value="LR Mitra — Custom Plan" />
-    <input type="text" name="name" placeholder="Your name" required
-      class="w-full bg-white/70 dark:bg-slate-800/70 border border-teal-200 dark:border-teal-800 rounded-xl px-4 py-3 outline-none focus:ring-2 focus:ring-teal-400" />
-    <input type="email" name="email" placeholder="Your email" required
-      class="w-full bg-white/70 dark:bg-slate-800/70 border border-teal-200 dark:border-teal-800 rounded-xl px-4 py-3 outline-none focus:ring-2 focus:ring-teal-400" />
-    <input type="tel" name="phone" placeholder="Phone (optional)"
-      class="w-full bg-white/70 dark:bg-slate-800/70 border border-teal-200 dark:border-teal-800 rounded-xl px-4 py-3 outline-none focus:ring-2 focus:ring-teal-400" />
-    <textarea name="message" rows="3" required
-      class="w-full bg-white/70 dark:bg-slate-800/70 border border-teal-200 dark:border-teal-800 rounded-xl px-4 py-3 outline-none focus:ring-2 focus:ring-teal-400">I'm interested in the LR Mitra Custom plan. Please share details.</textarea>
-    <button type="submit"
-      class="inline-flex items-center gap-2 bg-teal-700 text-white text-sm font-medium px-5 py-2.5 rounded-xl hover:bg-teal-800 transition-colors">
-      Send enquiry
-      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/></svg>
-    </button>
-  </form>
+  <details class="group">
+    <summary class="inline-flex cursor-pointer items-center gap-2 bg-teal-700 text-white text-sm font-medium px-5 py-2.5 rounded-xl hover:bg-teal-800 transition-colors marker:hidden list-none [&::-webkit-details-marker]:hidden">
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
+      <span class="group-open:hidden">Contact us for pricing</span>
+      <span class="hidden group-open:inline">Hide enquiry form</span>
+    </summary>
+    <form class="mt-4 space-y-3"
+          action="https://formspree.io/f/xeejoadk" method="POST">
+      <input type="hidden" name="_subject" value="LR Mitra Custom Plan Enquiry" />
+      <input type="hidden" name="product" value="LR Mitra — Custom Plan" />
+      <input type="text" name="name" placeholder="Your name" required
+        class="w-full bg-white/70 dark:bg-slate-800/70 border border-teal-200 dark:border-teal-800 rounded-xl px-4 py-3 outline-none focus:ring-2 focus:ring-teal-400" />
+      <input type="email" name="email" placeholder="Your email" required
+        class="w-full bg-white/70 dark:bg-slate-800/70 border border-teal-200 dark:border-teal-800 rounded-xl px-4 py-3 outline-none focus:ring-2 focus:ring-teal-400" />
+      <input type="tel" name="phone" placeholder="Phone (optional)"
+        class="w-full bg-white/70 dark:bg-slate-800/70 border border-teal-200 dark:border-teal-800 rounded-xl px-4 py-3 outline-none focus:ring-2 focus:ring-teal-400" />
+      <textarea name="message" rows="3" required
+        class="w-full bg-white/70 dark:bg-slate-800/70 border border-teal-200 dark:border-teal-800 rounded-xl px-4 py-3 outline-none focus:ring-2 focus:ring-teal-400">I'm interested in the LR Mitra Custom plan. Please share details.</textarea>
+      <button type="submit"
+        class="inline-flex items-center gap-2 bg-teal-700 text-white text-sm font-medium px-5 py-2.5 rounded-xl hover:bg-teal-800 transition-colors">
+        Send enquiry
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/></svg>
+      </button>
+    </form>
+  </details>
 </div>
 
 ---

--- a/layouts/partials/essentials/style.html
+++ b/layouts/partials/essentials/style.html
@@ -1,0 +1,80 @@
+<!--
+  Project override of themes/hugoplate/layouts/_partials/essentials/style.html.
+  The upstream partial (a) creates the Google Fonts <link> via document.createElement
+  in an inline <script>, and (b) loads the lazy stylesheet via the
+  media="print" + onload= swap trick. Both mutate the DOM after parse, which
+  drops the LLM-rendered-content score. We swap them for plain static <link>s.
+-->
+
+<!-- DNS preconnect -->
+<meta http-equiv="x-dns-prefetch-control" content="on" />
+<link rel="preconnect" href="https://use.fontawesome.com" crossorigin />
+<link rel="preconnect" href="//cdnjs.cloudflare.com" />
+<link rel="preconnect" href="//www.googletagmanager.com" />
+<link rel="preconnect" href="//www.google-analytics.com" />
+<link rel="dns-prefetch" href="https://use.fontawesome.com" />
+<link rel="dns-prefetch" href="//ajax.googleapis.com" />
+<link rel="dns-prefetch" href="//cdnjs.cloudflare.com" />
+<link rel="dns-prefetch" href="//www.googletagmanager.com" />
+<link rel="dns-prefetch" href="//www.google-analytics.com" />
+<link rel="dns-prefetch" href="//fonts.googleapis.com" />
+<link rel="dns-prefetch" href="//connect.facebook.net" />
+<link rel="dns-prefetch" href="//platform.linkedin.com" />
+<link rel="dns-prefetch" href="//platform.twitter.com" />
+
+<!-- google fonts (static <link>, not JS-injected — see header comment) -->
+{{ $pf:= site.Data.theme.fonts.font_family.primary }}
+{{ $sf:= site.Data.theme.fonts.font_family.secondary }}
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  rel="stylesheet"
+  href="https://fonts.googleapis.com/css2?family={{ $pf | safeURL }}{{ with $sf }}&family={{ . | safeURL }}{{ end }}&display=swap" />
+
+<!-- main styles -->
+{{ $styles := slice }}
+{{ $stylesLazy := slice }}
+
+{{ range site.Params.plugins.css }}
+  {{ if findRE "^http" .link }}
+    <link
+      crossorigin="anonymous"
+      media="all"
+      rel="stylesheet"
+      href="{{ .link | relURL }}"
+      {{ .attributes | safeHTMLAttr }} />
+  {{ else }}
+    {{ if not .lazy }}
+      {{ $styles = $styles | append (resources.Get .link) }}
+    {{ else }}
+      {{ $stylesLazy = $stylesLazy | append (resources.Get .link) }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ $mainCSS := resources.Get "css/main.css" }}
+{{ $tailwindOpts := dict "inlineImports" true }}
+{{ $tailwindCSS := $mainCSS | css.TailwindCSS $tailwindOpts }}
+
+{{ $styles = $styles | append $tailwindCSS }}
+{{ $styles = $styles | resources.Concat "css/style.css" }}
+
+{{ $stylesLazy = $stylesLazy | resources.Concat "css/style-lazy.css" }}
+
+{{ if hugo.IsProduction }}
+  {{ $styles = $styles | fingerprint }}
+  {{ $stylesLazy = $stylesLazy | minify | fingerprint }}
+{{ end }}
+
+
+<!-- link main style -->
+<link
+  href="{{ $styles.RelPermalink }}"
+  integrity="{{ $styles.Data.Integrity }}"
+  rel="stylesheet" />
+
+<!-- link lazy style (plain <link> — was media="print" + onload swap) -->
+<link
+  href="{{ $stylesLazy.RelPermalink }}"
+  integrity="{{ $stylesLazy.Data.Integrity }}"
+  rel="stylesheet" />


### PR DESCRIPTION
Three changes that lift the static-rendered % (was 32% dynamic):

- Override style.html: replace the inline <script> that injects the Google Fonts <link> with a static <link>, and drop the media="print" + onload swap trick on the lazy stylesheet.
- Override assets/js/main.js: Swiper loop:false so it no longer clones testimonial slides into the DOM at init.
- Convert the LR Mitra Custom enquiry form from a class="hidden" div toggled by JS to a <details>/<summary> element — content lives in the initial HTML even while collapsed.